### PR TITLE
Added code to set USB::USB-SPECIAL-ENABLED? to TRUE at boot

### DIFF
--- a/usb_3_core_and_cdc.fs
+++ b/usb_3_core_and_cdc.fs
@@ -784,6 +784,7 @@ begin-module usb-core
     0 sof-callback-handler !
     USB_DPRAM_Base dpram-size 0 fill
     init-usb-default-endpoints
+    true usb::usb-special-enabled? !
     false usb-device-connected? !
     false usb-device-configured? !
     false line-notification-complete? !


### PR DESCRIPTION
Made a fix to set `usb::usb-special-enabled?` to `true` on boot.